### PR TITLE
Enable CORS to allow flutter to interact with backend

### DIFF
--- a/API/Minitwit.API/Startup.cs
+++ b/API/Minitwit.API/Startup.cs
@@ -28,7 +28,6 @@ namespace Minitwit.API
         }
 
         public IConfiguration Configuration { get; }
-        readonly string MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)

--- a/API/Minitwit.API/Startup.cs
+++ b/API/Minitwit.API/Startup.cs
@@ -28,6 +28,7 @@ namespace Minitwit.API
         }
 
         public IConfiguration Configuration { get; }
+        readonly string MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -54,6 +55,12 @@ namespace Minitwit.API
             //services.AddScoped<CustomDbContext>();
             //logger.Log(LogLevel.Error, connString);
             services.AddDbContext<CustomDbContext>(o => o.UseMySql(connString));
+            services.AddCors(o => o.AddPolicy("MyPolicy", builder =>
+            {
+                builder.AllowAnyOrigin()
+                       .AllowAnyMethod()
+                       .AllowAnyHeader();
+            }));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -77,6 +84,7 @@ namespace Minitwit.API
             app.UseRouting();
 
             //app.UseAuthorization();
+            app.UseCors("MyPolicy");
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
Enable CORS settings for all origns.
This can be fixed at a later point to only allow the frontend to have CORS enabled. However, for now we don't care too much about security and this will for sure open up for the frontend.

**NOTE:**
Do not merge until Thursday when we are all gathered :) 